### PR TITLE
Add workflow for label sync

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,17 @@
+name: Manage org labels
+on:
+    workflow_dispatch:
+  schedule:
+      - cron: '0 9 * * *'
+
+  jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-automation/manage-your-labels@v0.1.0
+        with:
+          github-token: ${{ secrets.ORG_LABEL_SYNC_TOKEN }}


### PR DESCRIPTION
This GitHub Actions workflow syncs labels across repositories using manage-your-labels and runs daily and on manual trigger.