### PR TITLE
Convert document and style workflows to workflow_call pattern

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,10 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    paths: ["R/**"]
+# Reusable workflow for running roxygen2 documentation
+# Called by thin wrapper workflows in individual package repos
+name: "R: Document"
 
-name: document.yaml
+on:
+  workflow_call:
 
 permissions: read-all
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,10 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  push:
-    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw", "**.[rR]profile"]
+# Reusable workflow for running styler code formatting
+# Called by thin wrapper workflows in individual package repos
+name: "R: Style"
 
-name: style.yaml
+on:
+  workflow_call:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary
Convert `document.yaml` and `style.yaml` reusable workflows to use `workflow_call` triggers, enabling the thin wrapper pattern across all R packages.

## Changes
- `document.yaml`: Replace `on: push` with `on: workflow_call`
- `style.yaml`: Replace `on: push` with `on: workflow_call`

## Why?
These workflows previously used direct `push` triggers, which meant they couldn't be called by thin wrapper workflows in individual package repos. This change aligns them with the existing pattern used by `r-cmd-check.yaml`, `lint.yaml`, `pkgdown.yaml`, etc.

## Test plan
- [ ] Thin wrappers in templ.rpkg can call these workflows
- [ ] Workflows execute correctly when triggered via wrapper